### PR TITLE
Fixed up Account Operations

### DIFF
--- a/SCRA-F/Account/Backend/AccountErrors.swift
+++ b/SCRA-F/Account/Backend/AccountErrors.swift
@@ -19,6 +19,7 @@ enum AccountError: Error, LocalizedError {
     case notLoggedIn
     case propogatedError(String)
     case uniqueError(String)
+    case userNotFound(String)
     
     var errorDescription: String? {
         
@@ -41,6 +42,8 @@ enum AccountError: Error, LocalizedError {
             return NSLocalizedString(message, comment: "")
         case .uniqueError(let message):
             return NSLocalizedString(message, comment: "")
+        case .userNotFound(let username):
+            return NSLocalizedString("A user with the username '\(username)' could not be found.", comment: "")
         }
     }
 }

--- a/SCRA-F/Account/MVM/AccountViewModel.swift
+++ b/SCRA-F/Account/MVM/AccountViewModel.swift
@@ -21,7 +21,7 @@ class AccountViewModel: ObservableObject {
     init(user: String?) {
         
         self.accountManager.signInEmail(email: "KeefCheif.dev@gmail.com", password: "testprofile") { [unowned self] (_) in
-            self.accountManager.getAccountInfo { [unowned self] (accountModel, accountError) in
+            self.accountManager.getAccountInfo(username: nil) { [unowned self] (accountModel, accountError) in
                 
                 if let accountModel = accountModel {
                     self.model = accountModel

--- a/SCRA-FTests/AccountTests/AccountDBOperationsTests.swift
+++ b/SCRA-FTests/AccountTests/AccountDBOperationsTests.swift
@@ -13,7 +13,7 @@ import FirebaseAuth
 class AccountDBOperationsTests: XCTestCase {
     
     override func setUpWithError() throws {
-        FirebaseApp.configure()
+        //FirebaseApp.configure()
     }
     
     func testAccountOperations() throws {
@@ -42,12 +42,13 @@ class AccountDBOperationsTests: XCTestCase {
         
         let getAccountExpectation = XCTestExpectation(description: "get account")
         
-        account.getAccountInfo { (model, error) in
+        account.getAccountInfo(username: nil) { (model, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(model)
             XCTAssertNotNil(model!.username)
             XCTAssertNotNil(model!.displayUsername)
             XCTAssertEqual(model!.displayUsername, "TestUser")
+            XCTAssertFalse(model!.hasProfilePicture)
             getAccountExpectation.fulfill()
         }
         
@@ -55,13 +56,9 @@ class AccountDBOperationsTests: XCTestCase {
         
         let deleteExpectation = XCTestExpectation(description: "delete")
         
-        do {
-            try account.deleteAccount { error in
-                XCTAssertNil(error)
-                deleteExpectation.fulfill()
-            }
-        } catch {
-            XCTFail(error.localizedDescription)
+        account.deleteAccount { error in
+            XCTAssertNil(error)
+            deleteExpectation.fulfill()
         }
         
         wait(for: [deleteExpectation], timeout: 10)


### PR DESCRIPTION
- All errors in Account Operations are bubbled up via a completion instead of throwing
- The getAccountInfo method can now be passed a username to get an account other than the current user's account
- **If no username is passed in then the method returns the info from the current user's account**
- A userId lookup map has been added to the DB so that usernames can easily be used to find userIds
- **The userId lookup map does not remove references to accounts that have been deleted** this is done so that new accounts to not get the info of an account that might have existed already and to avoid confusion amongst users
- Testing fixed